### PR TITLE
chore(resources): raise requests/limits for hot pods

### DIFF
--- a/helm/authentik/values.yaml
+++ b/helm/authentik/values.yaml
@@ -34,7 +34,7 @@ worker:
   resources:
     requests:
       cpu: 250m
-      memory: 512Mi
+      memory: 640Mi
     limits:
       cpu: 500m
       memory: 1Gi

--- a/helm/monitoring/kube-prometheus-stack-values.yaml
+++ b/helm/monitoring/kube-prometheus-stack-values.yaml
@@ -37,7 +37,7 @@ prometheus:
     resources:
       requests:
         cpu: 50m
-        memory: 512Mi
+        memory: 640Mi
       limits:
         cpu: 500m
         memory: 2Gi
@@ -101,10 +101,10 @@ grafana:
   resources:
     requests:
       cpu: 100m
-      memory: 256Mi
+      memory: 384Mi
     limits:
       cpu: 500m
-      memory: 512Mi
+      memory: 768Mi
   
   service:
     type: LoadBalancer

--- a/helm/monitoring/loki-values.yaml
+++ b/helm/monitoring/loki-values.yaml
@@ -91,7 +91,7 @@ singleBinary:
   resources:
     requests:
       cpu: 25m
-      memory: 256Mi
+      memory: 320Mi
     limits:
       cpu: 200m
       memory: 1Gi

--- a/kubernetes/arr-stack/bazarr-single-deployment.yaml
+++ b/kubernetes/arr-stack/bazarr-single-deployment.yaml
@@ -42,7 +42,7 @@ spec:
           mountPath: /NAS
         resources:
           requests:
-            memory: "256Mi"
+            memory: "320Mi"
             cpu: "25m"
           limits:
             memory: "512Mi"

--- a/kubernetes/arr-stack/bazarr2-single-deployment.yaml
+++ b/kubernetes/arr-stack/bazarr2-single-deployment.yaml
@@ -42,7 +42,7 @@ spec:
           mountPath: /NAS
         resources:
           requests:
-            memory: "256Mi"
+            memory: "320Mi"
             cpu: "25m"
           limits:
             memory: "512Mi"

--- a/kubernetes/arr-stack/radarr-single-deployment.yaml
+++ b/kubernetes/arr-stack/radarr-single-deployment.yaml
@@ -52,8 +52,8 @@ spec:
             periodSeconds: 15
           resources:
             requests:
-              memory: "256Mi"
-              cpu: "10m"
+              memory: "320Mi"
+              cpu: "25m"
             limits:
               memory: "512Mi"
               cpu: "100m"

--- a/kubernetes/arr-stack/radarr2-single-deployment.yaml
+++ b/kubernetes/arr-stack/radarr2-single-deployment.yaml
@@ -52,8 +52,8 @@ spec:
             periodSeconds: 15
           resources:
             requests:
-              memory: "256Mi"
-              cpu: "10m"
+              memory: "320Mi"
+              cpu: "25m"
             limits:
               memory: "512Mi"
               cpu: "100m"

--- a/kubernetes/arr-stack/sonarr-single-deployment.yaml
+++ b/kubernetes/arr-stack/sonarr-single-deployment.yaml
@@ -52,11 +52,11 @@ spec:
           periodSeconds: 15
         resources:
           requests:
-            memory: "256Mi"
-            cpu: "10m"
-          limits:
-            memory: "512Mi"
+            memory: "384Mi"
             cpu: "100m"
+          limits:
+            memory: "768Mi"
+            cpu: "500m"
 
       volumes:
       - name: sonarr-config

--- a/kubernetes/jellyfin/deployment.yaml
+++ b/kubernetes/jellyfin/deployment.yaml
@@ -40,12 +40,12 @@ spec:
           imagePullPolicy: IfNotPresent
           resources:
             limits:
-              memory: "4Gi"
+              memory: "6Gi"
               cpu: "4"
               gpu.intel.com/i915: "1"
             requests:
-              memory: "2Gi"
-              cpu: "500m"
+              memory: "3584Mi"
+              cpu: "1"
               gpu.intel.com/i915: "1"
           env:
             - name: JELLYFIN_CACHE_DIR

--- a/kubernetes/jellyseerr/deployment.yaml
+++ b/kubernetes/jellyseerr/deployment.yaml
@@ -41,10 +41,10 @@ spec:
               subPath: config
           resources:
             requests:
-              memory: "256Mi"
-              cpu: "100m"
-            limits:
               memory: "512Mi"
+              cpu: "250m"
+            limits:
+              memory: "1Gi"
               cpu: "1500m"
       volumes:
         - name: jellyseerr-config

--- a/kubernetes/n8n/n8n-deployment.yaml
+++ b/kubernetes/n8n/n8n-deployment.yaml
@@ -65,10 +65,10 @@ spec:
           resources:
             requests:
               cpu: "50m"
-              memory: "250Mi"
+              memory: "384Mi"
             limits:
               cpu: "500m"
-              memory: "500Mi"
+              memory: "768Mi"
           volumeMounts:
             - mountPath: /home/node/.n8n
               name: n8n-claim0


### PR DESCRIPTION
## Summary
- Right-sizes resource requests/limits for pods running near memory request or hitting CPU limits, based on `kubectl top` audit
- Sonarr CPU limit raised 5x (was throttling during library scans at 99m of 100m); jellyfin gets a guaranteed 1 full CPU core and +1.5Gi memory headroom for transcoding
- Total cluster impact: ~+3Gi memory request, +650m CPU request — well within worker node headroom (currently 8.7Gi/16Gi memory, 1025m/4 CPU)

## Test plan
- [ ] ArgoCD auto-syncs (or hard-refresh) all touched apps: arr-stack, n8n, jellyfin, jellyseerr, monitoring (loki, kube-prometheus-stack), authentik
- [ ] Verify new values landed: `kubectl get pods -A -o custom-columns=NS:.metadata.namespace,POD:.metadata.name,MEM_REQ:.spec.containers[*].resources.requests.memory,MEM_LIM:.spec.containers[*].resources.limits.memory`
- [ ] No CrashLoopBackOff or restart-count increases on bumped pods
- [ ] Re-run `kubectl top pods -A` — bumped pods now in 60-85% of request band (was 90-100%)
- [ ] Sonarr library scan no longer caps at 100m CPU
- [ ] Node memory still under 70% on worker (`kubectl top nodes`)

## Out of scope
- Alloy + ArgoCD application-controller live pods aren't picking up their helm values (sync/path issue, not a values issue) — separate investigation
- CNPG `database-*` clusters — postgres-specific tuning to be done separately